### PR TITLE
Sync README updates to README_zh.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -35,7 +35,9 @@ frp version >= v0.31.0
 
 3. Register plugin in frps.
 
-    ```
+   INI:
+
+    ```ini
     # frps.ini
     [common]
     bind_port = 7000
@@ -46,11 +48,23 @@ frp version >= v0.31.0
     ops = Login
     ```
 
+    TOML:
+
+    ```toml
+    # frps.toml
+    bindPort = 7000
+
+    [[httpPlugins]]
+    addr = "127.0.0.1:7200"
+    path = "/handler"
+    ops = ["Login"]
+    ```
+
 4. Specify username and meta_token in frpc configure file.
 
-    For user1:
+    For user1 INI:
 
-    ```
+    ```ini
     # frpc.ini
     [common]
     server_addr = x.x.x.x
@@ -64,9 +78,23 @@ frp version >= v0.31.0
     remote_port = 6000
     ```
 
-    For user2:
+    For user1 TOML:
 
+    ```toml
+    serverAddr = "x.x.x.x"
+    serverPort = 7000
+    user = "user1"
+    metadatas.token = "123"
+
+    [[proxies]]
+    type = "tcp"
+    localPort = 22
+    remotePort = 6000
     ```
+
+    For user2 INI:
+
+    ```ini
     # frpc.ini
     [common]
     server_addr = x.x.x.x
@@ -77,5 +105,19 @@ frp version >= v0.31.0
     [ssh]
     type = tcp
     local_port = 22
-    remote_port = 6000
+    remote_port = 6001
+    ```
+
+    For user2 TOML:
+
+    ```toml
+    serverAddr = "x.x.x.x"
+    serverPort = 7000
+    user = "user2"
+    metadatas.token = "abc"
+
+    [[proxies]]
+    type = "tcp"
+    localPort = 22
+    remotePort = 6001
     ```

--- a/README_zh.md
+++ b/README_zh.md
@@ -35,6 +35,8 @@ fp-multiuser 会以一个单独的进程运行，并接收 frps 发送过来的 
 
 3. 在 frps 的配置文件中注册插件，并启动。
 
+   INI 格式:
+
     ```
     # frps.ini
     [common]
@@ -46,9 +48,21 @@ fp-multiuser 会以一个单独的进程运行，并接收 frps 发送过来的 
     ops = Login
     ```
 
+   TOML 格式:
+
+    ```toml
+    # frps.toml
+    bindPort = 7000
+
+    [[httpPlugins]]
+    addr = "127.0.0.1:7200"
+    path = "/handler"
+    ops = ["Login"]
+    ```
+
 4. 在 frpc 中指定用户名，在 meta 中指定 token，用户名以及 `meta_token` 的内容需要和之前创建的 token 文件匹配。
 
-    user1 的配置:
+    user1 的配置 INI 格式:
 
     ```
     # frpc.ini
@@ -64,7 +78,21 @@ fp-multiuser 会以一个单独的进程运行，并接收 frps 发送过来的 
     remote_port = 6000
     ```
 
-    user2 的配置:
+    user1 的配置 TOML 格式:
+
+    ```toml
+    serverAddr = "x.x.x.x"
+    serverPort = 7000
+    user = "user1"
+    metadatas.token = "123"
+
+    [[proxies]]
+    type = "tcp"
+    localPort = 22
+    remotePort = 6000
+    ```
+
+    user2 的配置 INI 格式:
 
     ```
     # frpc.ini
@@ -77,5 +105,19 @@ fp-multiuser 会以一个单独的进程运行，并接收 frps 发送过来的 
     [ssh]
     type = tcp
     local_port = 22
-    remote_port = 6000
+    remote_port = 6001
+    ```
+
+    user2 的配置 TOML 格式:
+
+    ```toml
+    serverAddr = "x.x.x.x"
+    serverPort = 7000
+    user = "user2"
+    metadatas.token = "abc"
+
+    [[proxies]]
+    type = "tcp"
+    localPort = 22
+    remotePort = 6001
     ```


### PR DESCRIPTION
Updates the `README_zh.md` file to include TOML configuration examples and differentiates between INI and TOML configurations, translated into Chinese.

- **Adds TOML configuration examples** for both frps and frpc, providing users with alternative configuration options.
- **Differentiates between INI and TOML configurations** by clearly labeling sections, making it easier for users to follow the format they prefer.
- **Includes configurations for user1 and user2** in both INI and TOML formats, ensuring comprehensive examples for different user scenarios.


---

For more details, open the [Copilot Workspace session](https://copilot-workspace.githubnext.com/gofrp/fp-multiuser/pull/15?shareId=6c3a46c9-efe7-48da-bf0b-a0edfad4e158).